### PR TITLE
Return empty set when no subscribers to event

### DIFF
--- a/src/Storage/Manager.php
+++ b/src/Storage/Manager.php
@@ -86,9 +86,11 @@ class Manager implements StoresSubscriptions
         $subscriberIds = array_map([$this, 'channelKey'], $subscriberIds);
         $subscribers = $this->connection->command('mget', [$subscriberIds]);
 
-        return collect(
-            array_map([$this, 'unserialize'], $subscribers)
-        )->filter();
+        return $subscribers === false
+            ? new Collection
+            : collect(
+                array_map([$this, 'unserialize'], $subscribers)
+            )->filter();
     }
 
     /**


### PR DESCRIPTION
The existing code throws a fault when there are no subscribers to an event because the Redis "mget" query will return false instead of an array. The subsequent array_map() then fails.