### PR TITLE
Add channel events and Laravel 8 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,16 +12,16 @@
   "require": {
     "php": ">=7.2",
     "nuwave/lighthouse": "^4",
-    "illuminate/support": "^7.7",
-    "illuminate/console": "^7.7",
-    "illuminate/cache": "^7.7",
-    "illuminate/redis": "^7.7",
-    "illuminate/broadcasting": "^7.7",
+    "illuminate/support": "^7.7|^8.0",
+    "illuminate/console": "^7.7|^8.0",
+    "illuminate/cache": "^7.7|^8.0",
+    "illuminate/redis": "^7.7|^8.0",
+    "illuminate/broadcasting": "^7.7|^8.0",
     "ext-json": "*"
   },
   "require-dev": {
     "phpunit/phpunit": "^8",
-    "laravel/framework": "^7.7",
+    "laravel/framework": "^7.7|^8.0",
     "mockery/mockery": "^1.3"
   },
   "autoload": {

--- a/src/Console/LighthouseSubscribeCommand.php
+++ b/src/Console/LighthouseSubscribeCommand.php
@@ -64,14 +64,16 @@ class LighthouseSubscribeCommand extends Command
 
         $this->logEvent($memberCount, $channel);
 
+        $storeCount = $this->knownChannels[$channel] ?? 0;
+
         // The laravel echo server sends one event before joining and one after.
         // So the first event has member count 0, but we do not know the channel.
-        if ($memberCount === 0 && isset($this->knownChannels[$channel])) {
+        if ($memberCount === 0 && $storeCount !== 0) {
             // Someone left a channel that we know from before and it is now empty.
             return $this->deleteSubscriber($channel);
         }
 
-        if (!$this->option('no-events')) {
+        if (!$this->option('no-events') && $memberCount > $storeCount) {
             $subscriber = $this->storage->subscriberByChannel($channel);
 
             if ($subscriber) {

--- a/src/Events/ClientConnected.php
+++ b/src/Events/ClientConnected.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace thekonz\LighthouseRedisBroadcaster\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Nuwave\Lighthouse\Subscriptions\Subscriber;
+
+class ClientConnected
+{
+  use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * @var Subscriber
+     */
+    public $subscriber;
+
+    public function __construct(Subscriber $subscriber)
+    {
+        $this->subscriber = $subscriber;
+    }
+}

--- a/src/Events/ClientDisconnected.php
+++ b/src/Events/ClientDisconnected.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace thekonz\LighthouseRedisBroadcaster\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Nuwave\Lighthouse\Subscriptions\Subscriber;
+
+class ClientDisconnected
+{
+  use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * @var Subscriber
+     */
+    public $subscriber;
+
+    public function __construct(Subscriber $subscriber)
+    {
+        $this->subscriber = $subscriber;
+    }
+}

--- a/src/Storage/Manager.php
+++ b/src/Storage/Manager.php
@@ -86,9 +86,11 @@ class Manager implements StoresSubscriptions
         $subscriberIds = array_map([$this, 'channelKey'], $subscriberIds);
         $subscribers = $this->connection->command('mget', [$subscriberIds]);
 
-        return collect(
-            array_map([$this, 'unserialize'], $subscribers)
-        )->filter();
+        return $subscribers === false
+            ? new Collection
+            : collect(
+                array_map([$this, 'unserialize'], $subscribers)
+            )->filter();
     }
 
     /**


### PR DESCRIPTION
This introduces two events "ClientConnected" and "ClientDisconnected". It checks the multiple events sent by laravel-echo-server to make sure each of these is sent only once per subscription session. It depends on the "lighthouse:subscribe" method to work.

This also adds Laravel 8 support by incrementing the version number. Sorry, I should have prepared a PR for this separately.